### PR TITLE
Cancel SNAPSHOT publishing

### DIFF
--- a/.github/workflows/snapshots.yml
+++ b/.github/workflows/snapshots.yml
@@ -6,7 +6,7 @@ on:
 
 concurrency:
   group: snapshots
-  cancel-in-progress: false
+  cancel-in-progress: true
 
 jobs:
   publishMavenCentral:


### PR DESCRIPTION
It will be overwritten immediately, so waiting is useless.