### PR TITLE
Simplify the `files.from()` example

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ plugins {
 
 kfx {
     register<OpenApi>("myApi") {
-        files.from(file("myApi.json"))
+        files.from("myApi.json")
         dependencies {
             compiler(kotlinClasses())
             compiler(kotlinxJson())


### PR DESCRIPTION
Gradle interprets `String` objects as file paths.