### PR TITLE
Only depend on the core / API of Ktor for generated code

### DIFF
--- a/gradle-plugin/src/main/kotlin/io/github/hfhbd/kfx/KfxDependencies.kt
+++ b/gradle-plugin/src/main/kotlin/io/github/hfhbd/kfx/KfxDependencies.kt
@@ -9,9 +9,9 @@ interface KfxDependencies : Dependencies {
 
     fun kotlinClasses(): ExternalModuleDependency = dependencyFactory.create("$GROUP:kotlin:$VERSION")
 
-    fun ktorClient(): ExternalModuleDependency = dependencyFactory.create("$GROUP:ktor-client:$VERSION")
+    fun ktorClient(): ExternalModuleDependency = dependencyFactory.create("$GROUP:ktor-client-core:$VERSION")
 
-    fun ktorServer(): ExternalModuleDependency = dependencyFactory.create("$GROUP:ktor-server:$VERSION")
+    fun ktorServer(): ExternalModuleDependency = dependencyFactory.create("$GROUP:ktor-server-core:$VERSION")
 
     fun springServer(): ExternalModuleDependency = dependencyFactory.create("$GROUP:spring-server:$VERSION")
 


### PR DESCRIPTION
The actual engine should be chosen by the implementation.